### PR TITLE
rework messaging

### DIFF
--- a/core/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IMessagingExchange.kt
+++ b/core/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IMessagingExchange.kt
@@ -1,0 +1,7 @@
+package dev.kaccelero.commons.messaging
+
+interface IMessagingExchange {
+
+    val exchange: String
+
+}

--- a/core/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IMessagingQueue.kt
+++ b/core/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IMessagingQueue.kt
@@ -1,0 +1,7 @@
+package dev.kaccelero.commons.messaging
+
+interface IMessagingQueue {
+
+    val queue: String
+
+}

--- a/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/DelayedMessagingService.kt
+++ b/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/DelayedMessagingService.kt
@@ -2,37 +2,38 @@ package dev.kaccelero.commons.messaging
 
 import dev.kaccelero.serializers.Serialization
 import dev.kourier.amqp.Field
-import dev.kourier.amqp.Properties
+import dev.kourier.amqp.properties
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 
 open class DelayedMessagingService(
-    exchange: String,
     host: String,
     user: String,
     password: String,
-    handleMessagingUseCase: IHandleMessagingUseCase,
+    exchange: IMessagingExchange,
+    queue: IMessagingQueue,
     keys: List<IMessagingKey>,
+    handleMessagingUseCaseFactory: () -> IHandleMessagingUseCase,
+    coroutineScope: CoroutineScope,
     json: Json? = null,
     listen: Boolean = true,
     persistent: Boolean = false,
     quorum: Boolean = false,
     dead: Boolean = false,
     maxXDeathCount: Int = 1,
-    connectionName: String = exchange,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    connectionName: String = queue.queue,
 ) : MessagingService(
-    exchange,
     host,
     user,
     password,
-    handleMessagingUseCase,
+    exchange,
+    queue,
     keys,
+    handleMessagingUseCaseFactory,
+    coroutineScope,
     json,
     listen,
     persistent,
@@ -40,24 +41,23 @@ open class DelayedMessagingService(
     dead,
     maxXDeathCount,
     connectionName,
-    coroutineScope
 ) {
 
-    override suspend fun exchangeDeclare(name: String, type: String, arguments: Map<String, Field>) {
+    override suspend fun exchangeDeclare(exchange: IMessagingExchange, type: String, arguments: Map<String, Field>) {
         channel?.exchangeDeclare(
-            name = name,
+            name = exchange.exchange,
             type = "x-delayed-message",
             durable = true,
-            autoDelete = false,
             arguments = arguments + mapOf("x-delayed-type" to Field.LongString(type))
         )
-        exchangeDeclareAdditionalResources(name, type, arguments)
+        exchangeDeclareAdditionalResources(exchange, type, arguments)
     }
 
     suspend inline fun <reified T> publish(
         routingKey: IMessagingKey,
         value: T,
         publishAt: Instant?,
+        exchange: IMessagingExchange? = null,
         persistent: Boolean = false,
         attempts: Int = 3,
         delay: Long = 5000,
@@ -66,12 +66,12 @@ open class DelayedMessagingService(
             val delay = publishAt?.minus(Clock.System.now())?.inWholeMilliseconds ?: 0
             channel!!.basicPublish(
                 body = (json ?: Serialization.json).encodeToString(value).toByteArray(),
-                exchange = exchange,
+                exchange = (exchange ?: this.exchange).exchange,
                 routingKey = routingKey.key,
-                properties = Properties(
-                    deliveryMode = if (persistent || this.persistent) 2u else 1u,
+                properties = properties {
+                    deliveryMode = if (persistent || this@DelayedMessagingService.persistent) 2u else 1u
                     headers = mapOf("x-delay" to Field.Long(delay))
-                ),
+                },
             )
         }
     }

--- a/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IHandleMessagingUseCase.kt
+++ b/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/IHandleMessagingUseCase.kt
@@ -1,5 +1,5 @@
 package dev.kaccelero.commons.messaging
 
-import dev.kaccelero.usecases.ITripleSuspendUseCase
+import dev.kaccelero.usecases.IPairSuspendUseCase
 
-interface IHandleMessagingUseCase : ITripleSuspendUseCase<IMessagingService, IMessagingKey, String, Unit>
+interface IHandleMessagingUseCase : IPairSuspendUseCase<IMessagingKey, String, Unit>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -130,7 +130,7 @@ dependencyResolutionManagement {
             // Others
             library("bcrypt", "at.favre.lib:bcrypt:0.10.2")
             library("sentry", "io.sentry:sentry-kotlin-extensions:8.14.0")
-            library("amqp", "dev.kourier:amqp-client-robust:0.2.0")
+            library("amqp", "dev.kourier:amqp-client-robust:0.2.1")
         }
     }
 }


### PR DESCRIPTION
Messaging is now queue based instead of exchange based. It allows to publish everything to one exchange and consume inside different queues based on selected routing keys (what's usually done in microservices architecture)

Also fixes #9 